### PR TITLE
Revert APA-IT XML support and make PageXmlParser inheritable

### DIFF
--- a/src/Core/Elements.cpp
+++ b/src/Core/Elements.cpp
@@ -1368,46 +1368,4 @@ bool TableCell::compareCells(const QSharedPointer<rdf::TableCell> l1, const QSha
 	return *l1 < *l2;
 }
 
-ApaRegion::ApaRegion(const Type & type) : TextLine(type) {
-
-	// default to apa-it
-	if (mType == type_unknown)
-		mType = Region::type_apa_it_text;
-}
-
-bool ApaRegion::read(QXmlStreamReader & reader) {
-
-	//RegionXmlHelper& rm = RegionXmlHelper::instance();
-
-	// add text
-	if (!reader.text().isEmpty()) {
-		mText = reader.text().toUtf8();
-		qDebug() << "I am reading: "<< reader.text().toUtf8();
-	}
-	else
-		return Region::read(reader);
-
-	return true;
-}
-
-void ApaRegion::readAttributes(QXmlStreamReader & reader) {
-
-	bool ok = false;
-	double x1 = reader.attributes().value("x1").toDouble(&ok);	if (!ok) return;
-	double x2 = reader.attributes().value("x2").toDouble(&ok);	if (!ok) return;
-	double y1 = reader.attributes().value("y1").toDouble(&ok);	if (!ok) return;
-	double y2 = reader.attributes().value("y2").toDouble(&ok);	if (!ok) return;
-
-	Polygon p;
-	p << Vector2D(x1, y1);
-	p << Vector2D(x2, y1);
-	p << Vector2D(x2, y2);
-	p << Vector2D(x1, y2);
-
-	mPoly = p;
-
-	Region::readAttributes(reader);
-}
-
-
 }

--- a/src/Core/Elements.h
+++ b/src/Core/Elements.h
@@ -79,9 +79,6 @@ public:
 		type_chart,
 		type_noise,
 
-		// APA-IT not part of PAGE
-		type_apa_it_text,
-
 		type_end
 	};
 
@@ -242,6 +239,9 @@ protected:
 	QVector<int> mCornerPts;
 };
 
+
+
+
 class DllCoreExport TextLine : public Region {
 
 public:
@@ -264,20 +264,6 @@ protected:
 	BaseLine mBaseLine;
 	QString mText;
 	bool mTextPresent = false;
-};
-
-class DllCoreExport ApaRegion : public TextLine {
-
-public:
-	ApaRegion(const Type& type = Type::type_unknown);
-
-	virtual bool read(QXmlStreamReader& reader) override;
-	virtual void readAttributes(QXmlStreamReader& reader) override;
-
-protected:
-	double mArea = 0;	// TODO
-	double mAngle = 0;
-	// min font...
 };
 
 

--- a/src/Core/ElementsHelper.cpp
+++ b/src/Core/ElementsHelper.cpp
@@ -278,9 +278,6 @@ QString RegionManager::typeName(const Region::Type& type) const {
 	case Region::type_graphic:		return "GraphicRegion";
 	case Region::type_chart:		return "ChartRegion";
 	case Region::type_noise:		return "NoiseRegion";
-
-	// APA-IT
-	case Region::type_apa_it_text:	return "text";
 	}
 
 	return "Unknown";
@@ -322,9 +319,6 @@ QSharedPointer<Region> RegionManager::createRegion(const Region::Type & type) co
 		return QSharedPointer<TableRegion>::create(type);
 	case Region::type_table_cell:
 		return QSharedPointer<TableCell>::create(type);
-	// APA-IT XMLs - not part of PAGE
-	case Region::type_apa_it_text:
-		return QSharedPointer<ApaRegion>::create(type);
 		// Add new types here...
 	default:
 		qWarning() << "unknown region type" << type;

--- a/src/Core/PageParser.h
+++ b/src/Core/PageParser.h
@@ -95,9 +95,9 @@ protected:
 
 	QSharedPointer<PageElement> mPage;
 
-	QSharedPointer<PageElement> parse(const QString& xmlPath) const;
-	void parseRegion(QXmlStreamReader& reader, QSharedPointer<Region> parent) const;
-	void parseMetadata(QXmlStreamReader& reader, QSharedPointer<PageElement> page) const;
+	virtual QSharedPointer<PageElement> parse(const QString& xmlPath) const;
+	virtual void parseRegion(QXmlStreamReader& reader, QSharedPointer<Region> parent) const;
+	virtual void parseMetadata(QXmlStreamReader& reader, QSharedPointer<PageElement> page) const;
 
 	QByteArray writePageElement() const;
 	void writeMetaData(QXmlStreamWriter& writer) const;


### PR DESCRIPTION
1. Reverts the commit which added support for APA-IT XMLs
2. Makes the PageXmlParser class inheritable
