### PR TITLE
TextRegion and TextEquiv classes

### DIFF
--- a/src/Core/Elements.cpp
+++ b/src/Core/Elements.cpp
@@ -545,13 +545,11 @@ TextEquiv::TextEquiv() {
 }
 
 /// <summary>
-/// Initializes a new instance of the <see cref="TextEquiv"/> class with unicode and optional plain text.
+/// Initializes a new instance of the <see cref="TextEquiv" /> class with some text.
 /// </summary>
 /// <param name="text">The text.</param>
-/// <param name="plainText">The plain text.</param>
-TextEquiv::TextEquiv(const QString& text, const QString& plainText) {
+TextEquiv::TextEquiv(const QString& text) {
 	mText = text;
-	mPlainText = plainText;
 	mIsNull = false;
 }
 
@@ -584,12 +582,17 @@ TextEquiv TextEquiv::read(QXmlStreamReader & reader) {
 		}
 	}
 
-	// Unicode text must be present for the TextEquiv element to be valid (according to schema)
+	// use plain text only if unicode is missing (according to schema, unicode should always be present)
+	if (text.isEmpty() && !plainText.isEmpty()) {
+		text = plainText;
+	}
+
+	// if the element contains no text at all, it is null / invalid
 	if (text.isNull()) {
 		return TextEquiv();
 	}
 
-	return TextEquiv(text, plainText);
+	return TextEquiv(text);
 }
 
 void TextEquiv::write(QXmlStreamWriter & writer) const {
@@ -597,9 +600,6 @@ void TextEquiv::write(QXmlStreamWriter & writer) const {
 
 	if (!mIsNull) {
 		writer.writeStartElement(rm.tag(RegionXmlHelper::tag_text_equiv));
-		if (!mPlainText.isNull()) {
-			writer.writeTextElement(rm.tag(RegionXmlHelper::tag_plain_text), mPlainText);
-		}
 		writer.writeTextElement(rm.tag(RegionXmlHelper::tag_unicode), mText);
 		writer.writeEndElement(); // </TextEquiv>
 	}
@@ -607,10 +607,6 @@ void TextEquiv::write(QXmlStreamWriter & writer) const {
 
 QString TextEquiv::text() const {
 	return mText;
-}
-
-QString TextEquiv::plainText() const {
-	return mPlainText;
 }
 
 bool TextEquiv::isNull() const {

--- a/src/Core/Elements.h
+++ b/src/Core/Elements.h
@@ -253,6 +253,26 @@ protected:
 	QVector<int> mCornerPts;
 };
 
+class DllCoreExport TextEquiv {
+
+public:
+	TextEquiv();
+	TextEquiv(const QString& text, const QString& plainText = QString());
+
+	static TextEquiv read(QXmlStreamReader& reader);
+
+	void write(QXmlStreamWriter& writer) const;
+
+	QString text() const;
+	QString plainText() const;
+	bool isNull() const;
+
+protected:
+	QString mPlainText; 
+	QString mText; // unicode
+	bool mIsNull = false;
+};
+
 class DllCoreExport TextLine : public Region {
 
 public:
@@ -273,10 +293,27 @@ public:
 
 protected:
 	BaseLine mBaseLine;
-	QString mText;
-	bool mTextPresent = false;
+	TextEquiv mTextEquiv;
 };
 
+class DllCoreExport TextRegion : public Region {
+	
+public:
+	TextRegion(const Type& type = Type::type_unknown);
+
+	void setText(const QString& text);
+	QString text() const;
+
+	virtual bool read(QXmlStreamReader& reader) override;
+	virtual void write(QXmlStreamWriter& writer) const override;
+
+	virtual QString toString(bool withChildren = false) const override;
+	
+	virtual void draw(QPainter& p, const RegionTypeConfig& config) const override;
+
+protected:
+	TextEquiv mTextEquiv;
+};
 
 class DllCoreExport SeparatorRegion : public Region {
 

--- a/src/Core/Elements.h
+++ b/src/Core/Elements.h
@@ -257,18 +257,16 @@ class DllCoreExport TextEquiv {
 
 public:
 	TextEquiv();
-	TextEquiv(const QString& text, const QString& plainText = QString());
+	TextEquiv(const QString& text);
 
 	static TextEquiv read(QXmlStreamReader& reader);
 
 	void write(QXmlStreamWriter& writer) const;
 
 	QString text() const;
-	QString plainText() const;
 	bool isNull() const;
 
 protected:
-	QString mPlainText; 
 	QString mText; // unicode
 	bool mIsNull = false;
 };

--- a/src/Core/ElementsHelper.cpp
+++ b/src/Core/ElementsHelper.cpp
@@ -305,6 +305,7 @@ QSharedPointer<Region> RegionManager::createRegion(const Region::Type & type) co
 	case Region::type_separator:
 		return QSharedPointer<SeparatorRegion>::create(type);
 	case Region::type_text_region:
+		return QSharedPointer<TextRegion>::create(type);
 	case Region::type_text_line:
 	case Region::type_word:
 		return QSharedPointer<TextLine>::create(type);

--- a/src/Core/PixelSet.cpp
+++ b/src/Core/PixelSet.cpp
@@ -1352,7 +1352,8 @@ bool TextBlock::remove(const QSharedPointer<TextLineSet>& tl) {
 
 QSharedPointer<Region> TextBlock::toTextRegion() const {
 
-	QSharedPointer<Region> r(new Region(Region::type_text_region, id()));
+	QSharedPointer<TextRegion> r(new TextRegion(Region::type_text_region));
+	r->setId(id());
 	r->setPolygon(mPoly);
 
 	for (auto tl : mTextLines)


### PR DESCRIPTION
Added TextRegion class, since it is different from a TextLine. Text stored in TextEquiv tags is now represented as TextEquiv objects.

Not sure about the TextRegion creation in TextBlockSet::toTextRegion, but it shouldn't be affected.