### PR TITLE
Added the option to define layers by region types

### DIFF
--- a/src/Core/Elements.h
+++ b/src/Core/Elements.h
@@ -398,10 +398,12 @@ public:
 	QDateTime dateModified() const;
 
 	void setLayers(const QVector<QSharedPointer<LayerElement>>& layers);
-	QVector<QSharedPointer<LayerElement>> layers();
+	QVector<QSharedPointer<LayerElement>> layers() const;
 
 	void setDefaultLayer(const QSharedPointer<LayerElement>& defaultLayer);
-	QSharedPointer<LayerElement> defaultLayer();
+	QSharedPointer<LayerElement> defaultLayer() const;
+
+	void redefineLayersByType(const QVector<Region::Type>& layerTypeAssignment);
 
 	void sortLayers(bool checkIfSorted = false);
 

--- a/src/Core/PageParser.h
+++ b/src/Core/PageParser.h
@@ -82,7 +82,7 @@ public:
 		tag_end
 	};
 
-	bool read(const QString& xmlPath);
+	bool read(const QString& xmlPath, bool ignoreLayers = false);
 	void write(const QString& xmlPath, const QSharedPointer<PageElement> pageElement);
 
 	QString tagName(const RootTags& tag) const;
@@ -96,10 +96,10 @@ protected:
 
 	QSharedPointer<PageElement> mPage;
 
-	virtual QSharedPointer<PageElement> parse(const QString& xmlPath) const;
+	virtual QSharedPointer<PageElement> parse(const QString& xmlPath, bool ignoreLayers = false) const;
 	virtual void parseRegion(QXmlStreamReader& reader, QSharedPointer<Region> parent) const;
 	virtual void parseMetadata(QXmlStreamReader& reader, QSharedPointer<PageElement> page) const;
-	virtual void parseLayers(QXmlStreamReader& reader, QSharedPointer<PageElement> page) const;
+	virtual void parseLayers(QXmlStreamReader& reader, QSharedPointer<PageElement> page, bool ignoreLayers = false) const;
 
 	QByteArray writePageElement() const;
 	void writeMetaData(QXmlStreamWriter& writer) const;

--- a/src/DebugThomas.h
+++ b/src/DebugThomas.h
@@ -9,8 +9,10 @@ public:
 	ThomasTest(const DebugConfig& config);
 
 	void test();
-	void testLayout();
 	void testXml();
+	void testFeatureCollection();
+	void testTraining();
+	void testClassification();
 
 private:
 	DebugConfig mConfig;


### PR DESCRIPTION
1. The layers in the xml document can now be completely ignored during parsing.
2. Layers can be defined after parsing the page, so that each layer contains all regions of the same type. This also defines the zIndex order.

Reason for the changes: In use cases where every region should have its own layer (important for SuperPixelLabeler::createLabelImage), it can make sense to define the layers after reading the document instead of defining them directly in it, because of the added flexibility. = Separation of layer definition and xml content.